### PR TITLE
Refactor message receiving and processing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ setup:
 	GO15VENDOREXPERIMENT=1 glide install
 
 build: *.go fmt
-	go build -o build/bin/$(ARCH)/$(BINARY_NAME) $(GOBUILD_VERSION_ARGS) github.com/jtblin/$(BINARY_NAME)
+	go build -o build/bin/$(ARCH)/$(BINARY_NAME) $(GOBUILD_VERSION_ARGS) github.com/jtblin/gostatsd
 
 fmt:
 	gofmt -w=true -s $$(find . -type f -name '*.go' -not -path "./vendor/*")

--- a/example/example.go
+++ b/example/example.go
@@ -2,20 +2,26 @@ package main
 
 import (
 	"log"
+	"net"
 
 	"github.com/jtblin/gostatsd/statsd"
 	"github.com/jtblin/gostatsd/types"
+
+	"golang.org/x/net/context"
 )
 
 func main() {
-	f := func(m *types.Metric) {
+	f := func(ctx context.Context, m *types.Metric) {
 		log.Printf("%s", m)
 	}
 	r := statsd.MetricReceiver{
-		Addr: ":8125", Namespace: "stats", MaxReaders: 1,
-		MaxMessengers: 1, Handler: statsd.HandlerFunc(f),
+		Namespace: "stats",
+		Handler:   statsd.HandlerFunc(f),
 	}
-	r.ListenAndReceive()
-
-	select {}
+	c, err := net.ListenPacket("udp", ":8125")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer c.Close()
+	r.Receive(context.TODO(), c)
 }

--- a/gostatsd.go
+++ b/gostatsd.go
@@ -92,8 +92,6 @@ func main() {
 		ExpiryInterval:   v.GetDuration(statsd.ParamExpiryInterval),
 		FlushInterval:    v.GetDuration(statsd.ParamFlushInterval),
 		MaxReaders:       v.GetInt(statsd.ParamMaxReaders),
-		MaxWorkers:       v.GetInt(statsd.ParamMaxWorkers),
-		MaxMessengers:    v.GetInt(statsd.ParamMaxMessengers),
 		MetricsAddr:      v.GetString(statsd.ParamMetricsAddr),
 		Namespace:        v.GetString(statsd.ParamNamespace),
 		PercentThreshold: toSlice(v.GetString(statsd.ParamPercentThreshold)),

--- a/statsd/aggregator_test.go
+++ b/statsd/aggregator_test.go
@@ -26,7 +26,6 @@ func newFakeMetricAggregator() (backend.MetricSender, *MetricAggregator) {
 		[]float64{float64(90)},
 		time.Duration(10)*time.Second,
 		time.Duration(5)*time.Minute,
-		2,
 		[]string{},
 	)
 }

--- a/statsd/receiver_test.go
+++ b/statsd/receiver_test.go
@@ -133,11 +133,6 @@ func (fpc FakePacketConn) SetDeadline(t time.Time) error                      { 
 func (fpc FakePacketConn) SetReadDeadline(t time.Time) error                  { return nil }
 func (fpc FakePacketConn) SetWriteDeadline(t time.Time) error                 { return nil }
 
-func manageQueue(mq messageQueue) {
-	for range mq {
-	}
-}
-
 // Need to change MetricReceiver.receive to a finite loop to be able to run the benchmark
 //func BenchmarkReceive(b *testing.B) {
 //	mq := make(messageQueue, maxQueueSize)

--- a/tester/Makefile
+++ b/tester/Makefile
@@ -16,7 +16,7 @@ setup:
 	GO15VENDOREXPERIMENT=1 glide install
 
 build: *.go fmt
-	go build -o $(BINARY_NAME) $(GOBUILD_VERSION_ARGS) github.com/jtblin/$(BINARY_NAME)
+	go build -o $(BINARY_NAME) $(GOBUILD_VERSION_ARGS) github.com/jtblin/gostatsd/tester
 
 fmt:
 	gofmt -w=true -s $(shell find . -type f -name '*.go' -not -path "./vendor/*")


### PR DESCRIPTION
The idea is to use MaxReaders workers to read from socket, parse message, push metrics onto the queue. Metrics aggregator also uses just one goroutine to process metrics from the queue. All this reduces contention on channels and locks (in case of aggregator).

This is an initial implementation. Probably can be improved, but it is time to have some sleep :)
WDYT?
